### PR TITLE
Refactor sphere root handling

### DIFF
--- a/src/geo.rs
+++ b/src/geo.rs
@@ -1,6 +1,7 @@
 use core::f32;
 use std::{
-    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign}, rc::Rc
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    rc::Rc,
 };
 
 pub fn degrees_to_radians(degrees: f32) -> f32 {
@@ -46,11 +47,11 @@ impl Ray {
         let mut hit_record = HitRecord::default();
 
         if world.hit(&self, 0., f32::INFINITY, &mut hit_record) {
-            return 0.5 * (hit_record.normal + Color::new(1.,1.,1.));
+            return 0.5 * (hit_record.normal + Color::new(1., 1., 1.));
         }
         //if t > 0. {
-            //let n = (self.at(t) - Vec3::new(0., 0., -1.)).unit_vector();
-            //return 0.5 * Color::new(n.x + 1., n.y + 1., n.z + 1.);
+        //let n = (self.at(t) - Vec3::new(0., 0., -1.)).unit_vector();
+        //return 0.5 * Color::new(n.x + 1., n.y + 1., n.z + 1.);
         //}
 
         // Sky Box
@@ -276,19 +277,20 @@ impl Hittable for Sphere {
 
         let sqrtd = discriminant.sqrt();
 
-        let root = (h - sqrtd) / a;
-
+        let mut root = (h - sqrtd) / a;
         if root <= ray_tmin || ray_tmax <= root {
-            let root_pos = (h + sqrtd) / a;
-            if root_pos <= ray_tmin || ray_tmax <= root_pos {
+            root = (h + sqrtd) / a;
+            if root <= ray_tmin || ray_tmax <= root {
                 return false;
             }
-            hit_record.t = root;
-            hit_record.point = ray.at(hit_record.t);
-            let outward_normal = (hit_record.point - self.center) / self.radius;
-            hit_record.set_face_normal(&ray, &outward_normal);
         }
-            true
+
+        hit_record.t = root;
+        hit_record.point = ray.at(hit_record.t);
+        let outward_normal = (hit_record.point - self.center) / self.radius;
+        hit_record.set_face_normal(ray, &outward_normal);
+
+        true
     }
 }
 
@@ -298,23 +300,22 @@ pub struct HittableList {
 }
 
 impl HittableList {
-    pub fn add(&mut self, object: Rc<dyn Hittable>){
+    pub fn add(&mut self, object: Rc<dyn Hittable>) {
         self.objects.push(object);
     }
-    pub fn clear(&mut self){
+    pub fn clear(&mut self) {
         self.objects.clear();
     }
 }
 
 impl Hittable for HittableList {
-    
     fn hit(&self, ray: &Ray, ray_tmin: f32, ray_tmax: f32, hit_record: &mut HitRecord) -> bool {
         let mut temp_hr = HitRecord::default();
         let mut hit_anything = false;
         let mut closest_so_far = ray_tmax;
 
         for object in &self.objects {
-            if object.hit(ray, ray_tmin, closest_so_far, &mut temp_hr){
+            if object.hit(ray, ray_tmin, closest_so_far, &mut temp_hr) {
                 hit_anything = true;
                 closest_so_far = temp_hr.t;
                 *hit_record = temp_hr;
@@ -323,4 +324,3 @@ impl Hittable for HittableList {
         hit_anything
     }
 }
-


### PR DESCRIPTION
## Summary
- fix sphere hit logic to select valid root and assign hit data
- reuse mutable `root` for secondary check instead of temporary `root_pos`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6891f1eb29cc8320819ac031593adc8d